### PR TITLE
Fix missed files by replacing https download with git clone

### DIFF
--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -111,7 +111,7 @@ var targetPluginPath = path.join( basePath, path.basename( sourcePluginPath ) );
 	
 	rimraf.sync( sourcePath );
 	
-	downloadGH( "saucal/WordPress-Plugin-Boilerplate#" + data.branch, sourcePath, async function(err) {
+	downloadGH( "saucal/WordPress-Plugin-Boilerplate#" + data.branch, sourcePath, { clone: true }, async function(err) {
 		if ( err ) {
 			console.error( "Couldn't download from GitHub. Maybe the branch \"" + data.branch + "\" doesn't exist?" );
 			process.exit( 1 );

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -31,7 +31,7 @@ let targetPath = process.cwd();
 
 rimraf.sync( sourcePath );
 
-downloadGH( "saucal/project-gulp-boilerplate#" + data.branch, sourcePath, async function(err) {
+downloadGH( "saucal/project-gulp-boilerplate#" + data.branch, sourcePath, { clone: true }, async function(err) {
 	if ( err ) {
 		console.error( "Couldn't download from GitHub. Maybe the branch \"" + data.branch + "\" doesn't exist?" );
 		process.exit( 1 );


### PR DESCRIPTION
Not sure why, i suspect the https download of repo takes into account .gitattributes or maybe .gitignore or maybe both. Point is that while using https download files were missing from the scaffold's result. when changing to git clone the files are there.